### PR TITLE
🐛 Fix month in grammar

### DIFF
--- a/src/grammar.js
+++ b/src/grammar.js
@@ -29,7 +29,7 @@ const day = oneOf(
 const month = oneOf(
   makeRule(regex(/january/ui)),
   makeRule(regex(/february/ui)),
-  makeRule(regex(/mars/ui)),
+  makeRule(regex(/march/ui)),
   makeRule(regex(/april/ui)),
   makeRule(regex(/may/ui)),
   makeRule(regex(/june/ui)),


### PR DESCRIPTION
This PR introduces the following changes:

 - [x] :bug: Rename `mars` to `march`